### PR TITLE
Fix infinite loop when get_image_urls returns empty dict {}

### DIFF
--- a/src/scraper.py
+++ b/src/scraper.py
@@ -147,13 +147,13 @@ def get_manifest(search_key: str, image_cnt: int):
     while ( len(img_manifest.items()) < image_cnt ): 
         try:
             results = get_image_urls(search_key, results_page)
-            # if results == {}:
-            #     # No error was thrown, but we still got an empty dict from get_image_urls 
-            #     # Likely means there are no more results on the page.
-            #     # Without this, can get stuck in infinite loop.
-            #     # So, break out of while loop with what we have (if anything)
-            #     manifest_len = len(img_manifest.items())
-            #     break
+            if results == {}:
+                # No error was thrown, but we still got an empty dict from get_image_urls 
+                # Likely means there are no more results on the page.
+                # Without this, can get stuck in infinite loop.
+                # So, break out of while loop with what we have (if anything)
+                manifest_len = len(img_manifest.items())
+                break
 
             img_manifest.update(results)
             results_page += 1

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -143,7 +143,16 @@ def get_manifest(search_key: str, image_cnt: int):
     search_key = sanitize_query(search_key)
     while ( len(img_manifest.items()) < image_cnt ): 
         try:
-            img_manifest.update(get_image_urls(search_key, results_page))
+            results = get_image_urls(search_key, results_page)
+            if results == {}:
+                # No error was thrown, but we still got an empty dict from get_image_urls 
+                # Likely means there are no more results on the page.
+                # Without this, can get stuck in infinite loop.
+                # So, break out of while loop with what we have (if anything)
+                manifest_len = len(img_manifest.items())
+                break
+
+            img_manifest.update(results)
             results_page += 1
         except:
             print(f"err_cnt: {err_cnt}")

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -147,13 +147,13 @@ def get_manifest(search_key: str, image_cnt: int):
     while ( len(img_manifest.items()) < image_cnt ): 
         try:
             results = get_image_urls(search_key, results_page)
-            if results == {}:
-                # No error was thrown, but we still got an empty dict from get_image_urls 
-                # Likely means there are no more results on the page.
-                # Without this, can get stuck in infinite loop.
-                # So, break out of while loop with what we have (if anything)
-                manifest_len = len(img_manifest.items())
-                break
+            # if results == {}:
+            #     # No error was thrown, but we still got an empty dict from get_image_urls 
+            #     # Likely means there are no more results on the page.
+            #     # Without this, can get stuck in infinite loop.
+            #     # So, break out of while loop with what we have (if anything)
+            #     manifest_len = len(img_manifest.items())
+            #     break
 
             img_manifest.update(results)
             results_page += 1

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -54,11 +54,12 @@ def get_image_urls(query: str, page: int):
     Returns:
     all_images -- a hash map of structure (id, url)
     """
-
+    print("getting image_urls")
     all_images = {}
 
     try:
         response = requests.get(search_url.format(query, page), headers=headers)
+        print(response)
 
         if (response.status_code == 200):
             json_text = response.content.decode('utf8').removeprefix(")]}'")
@@ -141,6 +142,8 @@ def get_manifest(search_key: str, image_cnt: int):
 
     results_page = 0
     search_key = sanitize_query(search_key)
+
+    print(search_key)
     while ( len(img_manifest.items()) < image_cnt ): 
         try:
             results = get_image_urls(search_key, results_page)

--- a/src/scraper.py
+++ b/src/scraper.py
@@ -54,12 +54,10 @@ def get_image_urls(query: str, page: int):
     Returns:
     all_images -- a hash map of structure (id, url)
     """
-    print("getting image_urls")
     all_images = {}
 
     try:
         response = requests.get(search_url.format(query, page), headers=headers)
-        print(response)
 
         if (response.status_code == 200):
             json_text = response.content.decode('utf8').removeprefix(")]}'")
@@ -142,8 +140,6 @@ def get_manifest(search_key: str, image_cnt: int):
 
     results_page = 0
     search_key = sanitize_query(search_key)
-
-    print(search_key)
     while ( len(img_manifest.items()) < image_cnt ): 
         try:
             results = get_image_urls(search_key, results_page)


### PR DESCRIPTION
Hello,

Ran into this when I was using this great project! 

When you run a search that returns 0 results, the script gets stuck in the get_manifest() while loop.

Therefore, we check to see if there's an empty dict returned, and if so, break and take what results we have, which is often 0.

Otherwise we start spamming the Google endpoint with as many requests as python can manage to produce per second haha.

I did some testing on this, but I say probably worth approaching it from your own first principles. 

Here was the test I did:


#### With a query that returns 0 results, and some debug logging to see get_image_urls function calls

```
root@lvm1:~/google-image-scraper# python3 src/main.py "\"kj2h35kj5h5h25hj4235on235ov4n3v6op45i7567m567n25fffffffffffffffffjkh235gh\"" -c 5 -d ./images
"kj2h35kj5h5h25hj4235on235ov4n3v6op45i7567m567n25fffffffffffffffffjkh235gh"
getting image_urls
<Response [200]>
getting image_urls
<Response [200]>
getting image_urls
<Response [200]>
getting image_urls
<Response [200]>
getting image_urls
<Response [200]>
getting image_urls
<Response [200]>
getting image_urls
[...] ad infinitum until Google bans the IP

```
------------------------------------------------------------------------
#### With the present fix  enabled

```
root@lvm1:~/google-image-scraper# python3 src/main.py "\"kj2h35kj5h5h25hj4235on235ov4n3v6op45i7567m567n25fffffffffffffffffjkh235gh\"" -c 5 -d ./images
"kj2h35kj5h5h25hj4235on235ov4n3v6op45i7567m567n25fffffffffffffffffjkh235gh"
getting image_urls
<Response [200]>
Found 0 of 5 image sources
0it [00:00, ?it/s]

```

